### PR TITLE
Add security via JWT and roles

### DIFF
--- a/EvaluacionExamenes/pom.xml
+++ b/EvaluacionExamenes/pom.xml
@@ -41,6 +41,23 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.11.5</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/EvaluacionExamenes/src/main/java/sii/ms_evalexamenes/security/TokenUtils.java
+++ b/EvaluacionExamenes/src/main/java/sii/ms_evalexamenes/security/TokenUtils.java
@@ -1,0 +1,30 @@
+package sii.ms_evalexamenes.security;
+
+import java.util.List;
+import java.util.Map;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.SignatureException;
+
+@SuppressWarnings("unchecked")  // saltaba un aviso por la no comprobacion de tipos (en 'claims.get()')
+public class TokenUtils {
+    private final static String KEY = "4qhq8LrEBfYcaRHxhdb9zURb2rf87Ud9";
+
+    public static boolean comprobarAcceso(Map<String,String> header, List<String> userRoles) {
+        // Falta definir un formato estandar para el token
+        // Cuando el microservicio que deba ocuparse lo haga, se cambiará el código
+        String token = header.get("authorization").substring(7);	// Empieza por 'Bearer: ' (por postman)
+        Claims claims;
+        try {
+            // Si el token no es valido (por firma incorrecta o por fecha exp) salta la excepcion
+            claims = Jwts.parserBuilder().setSigningKey(KEY.getBytes()).build().parseClaimsJws(token).getBody();
+        } catch (SignatureException | ExpiredJwtException e) {
+            return false;
+        }
+        List<String> allowedRoles = claims.get("roles", List.class).stream().map(rol -> (String) rol).toList();
+        return userRoles.stream().anyMatch(rol -> allowedRoles.contains(rol));
+    }
+
+}

--- a/GestionCorrectores/pom.xml
+++ b/GestionCorrectores/pom.xml
@@ -41,8 +41,24 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.11.5</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
-
 	<build>
 		<plugins>
 			<plugin>

--- a/GestionCorrectores/src/main/java/sii/ms_corrector/security/TokenUtils.java
+++ b/GestionCorrectores/src/main/java/sii/ms_corrector/security/TokenUtils.java
@@ -1,0 +1,30 @@
+package sii.ms_corrector.security;
+
+import java.util.List;
+import java.util.Map;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.SignatureException;
+
+@SuppressWarnings("unchecked")  // saltaba un aviso por la no comprobacion de tipos (en 'claims.get()')
+public class TokenUtils {
+    private final static String KEY = "4qhq8LrEBfYcaRHxhdb9zURb2rf87Ud9";
+
+    public static boolean comprobarAcceso(Map<String,String> header, List<String> userRoles) {
+        // Falta definir un formato estandar para el token
+        // Cuando el microservicio que deba ocuparse lo haga, se cambiará el código
+        String token = header.get("authorization").substring(7);	// Empieza por 'Bearer: ' (por postman)
+        Claims claims;
+        try {
+            // Si el token no es valido (por firma incorrecta o por fecha exp) salta la excepcion
+            claims = Jwts.parserBuilder().setSigningKey(KEY.getBytes()).build().parseClaimsJws(token).getBody();
+        } catch (SignatureException | ExpiredJwtException e) {
+            return false;
+        }
+        List<String> allowedRoles = claims.get("roles", List.class).stream().map(rol -> (String) rol).toList();
+        return userRoles.stream().anyMatch(rol -> allowedRoles.contains(rol));
+    }
+
+}


### PR DESCRIPTION
Implementación de la tarea #23. Seguridad mediante JWT.
Para hacer uso de la clase `TokenUtils`, basta con seguir estos pasos para cada endpoint que queramos segurizar.
```java
@GetMapping("{id}")
// Añadimos a los parámetros la cabecera de la petición
public ResponseEntity<T> obtener( . . . @RequestHeader Map<String, String> header) {
    // Le pasamos la cabecera y el rol (o roles) que deberia tener quien quiera acceder a este endpoint
    // Una lista vacia implica que el endpoint es público (todos tiene acceso)
    if (!TokenUtils.comprobarAcceso(header, Arrays.asList("VICERRECTOR", "CORRECTOR"))) {
        throw new AccesoNoAutorizado();
    }
    // . . . continuamos con el metodo como habitualmente
}
```
Para crear tokens:
1. Seguir el enlace a la [web de JWT](https://jwt.io/).
2. Incluir el el *payload* unos datos como el ejemplo. El campo 'Subject' (`sub`) en principio no es relevante para este microservicio.
3. Copiar el token y pegar junto con la clave secreta en *postman* para hacer las pruebas.

Siendo la clave secreta: `sistemasinformacioninternet20222023sistemasinformacioninternet20222023`
Y el algoritmo de firma: `HS512`
Formato ejemplo para el token:
```json
{
  "roles": [
    "CORRECTOR",
    "VICERRECTORADO"
  ],
  "sub": "user",
  "iat": 1681910588,
  "exp": 1684502588
}
```
La fecha de expiración del token ejemplo está establecida con una duración de un mes (hasta el 19 de Mayo de 2023).